### PR TITLE
ASSETS: added in manifest, deleted in templates; HOTEL dependency

### DIFF
--- a/booking/__manifest__.py
+++ b/booking/__manifest__.py
@@ -1,15 +1,22 @@
 {
-    'name': 'Fredheim Booking',
-    'version': '1.0',
-    'summary': 'Module Summary',
-    'description': 'Module Description',
-    'category': 'Administration',
-    'author': 'Rick',
-    'website': 'Author Website',
-    'depends': ['base','web'],
+    "name": "Fredheim Booking",
+    "version": "1.0",
+    "summary": "Module Summary",
+    "description": "Module Description",
+    "category": "Administration",
+    "author": "Rick",
+    "website": "Author Website",
+    "depends": [
+        "hotel",
+        "web",
+    ],
     "data": [
-        "templates/assets.xml",
-        "templates/index.xml",
     ],
     "application": True,
+    "assets": {
+        "web.assets_backend": [
+            # "/booking/static/css/booking.css",
+            # "/booking/static/src/main.js",
+        ],
+    },
 }

--- a/booking/models/__init__.py
+++ b/booking/models/__init__.py
@@ -1,1 +1,1 @@
-from . import booking
+from . import hotel_folio

--- a/booking/models/booking.py
+++ b/booking/models/booking.py
@@ -1,4 +1,0 @@
-from odoo import models, fields
-
-class Booking(models.Model):
-    _name = "booking.booking"

--- a/booking/models/hotel_folio.py
+++ b/booking/models/hotel_folio.py
@@ -1,0 +1,4 @@
+from odoo import models, fields
+
+class HotelFolio(models.Model):
+    _inherit = "hotel.folio"

--- a/booking/templates/assets.xml
+++ b/booking/templates/assets.xml
@@ -1,8 +1,0 @@
-<odoo>
-    <template id="assets_frontend" inherit_id="web.assets_frontend">
-        <xpath expr="." position="inside">
-            <link rel="stylesheet" type="text/css" href="/booking/static/css/booking.css"/>
-            <script type="text/javascript" src="/booking/static/src/main.js"></script>
-        </xpath>
-    </template>
-</odoo>

--- a/booking/templates/index.xml
+++ b/booking/templates/index.xml
@@ -1,7 +1,0 @@
-<odoo>
-    <template id="booking_index">
-        <t t-call="web.layout">
-            <t t-set="main_component" t-value="'BookingApp'"/>
-        </t>
-    </template>
-</odoo>


### PR DESCRIPTION
Hi Rick,

The community has a hotel module with the fields needed to register a booking. So I suggest that the booking module depends on hotel. Today I have worked on it so we can install it in version 16.0.
`git clone https://github.com/norlinhenrik/vertical-hotel.git -b 16.0-mig-hotel`
Update addons_path and click Update Apps List.

In the manifest, I changed from web.assets_frontend to web.assets_backend. Then I changed the url ?**debug=assets**# and verified that I could see the booking.css in the browser assets. But afterwards the screen became blank. So I disabled the assets in the manifest and refreshed the browser, and then I could see Odoo normally.